### PR TITLE
Fix formatting bug in ToF sensor driver

### DIFF
--- a/src/mower/hardware/tof.py
+++ b/src/mower/hardware/tof.py
@@ -118,8 +118,8 @@ class VL53L0XSensors:
             return None
         except Exception as e:
             logging.error(
-                f"Error initializing {sensor_name} VL53L0X at " f"{
-                    hex(address)}: {e}")
+                f"Error initializing {sensor_name} VL53L0X at {hex(address)}: {e}"
+            )
             return None
 
     @staticmethod
@@ -196,8 +196,8 @@ class VL53L0XSensors:
                 try:
                     temp_sensor.set_address(right_target_addr)
                     logging.info(
-                        f"Right sensor addr changed to " f"{
-                            hex(right_target_addr)}.")
+                        f"Right sensor addr changed to {hex(right_target_addr)}."
+                    )
                     right_sensor_obj = temp_sensor
                 except Exception as e:
                     logging.error(
@@ -224,8 +224,7 @@ class VL53L0XSensors:
             # Or, address change failed and it's still at default.
             # We must reset the right sensor to free up the default address.
             logging.info(
-                f"Right sensor at "
-                f"{hex(_DEFAULT_I2C_ADDRESS)}. Resetting for Left sensor."
+                f"Right sensor at {hex(_DEFAULT_I2C_ADDRESS)}. Resetting for Left sensor."
             )
             xshut_right_pin.value = False
             time.sleep(0.05)
@@ -241,8 +240,8 @@ class VL53L0XSensors:
             if left_target_addr == _DEFAULT_I2C_ADDRESS:
                 left_sensor_obj = temp_sensor
                 logging.info(
-                    f"Left sensor init at default addr " f"{
-                        hex(_DEFAULT_I2C_ADDRESS)}.")
+                    f"Left sensor init at default addr {hex(_DEFAULT_I2C_ADDRESS)}."
+                )
             else:  # Should not happen with current constants
                 logging.error(
                     f"Left sensor target addr "
@@ -251,8 +250,8 @@ class VL53L0XSensors:
                 try:
                     temp_sensor.set_address(left_target_addr)
                     logging.info(
-                        f"Left sensor addr changed to " f"{
-                            hex(left_target_addr)}.")
+                        f"Left sensor addr changed to {hex(left_target_addr)}."
+                    )
                     left_sensor_obj = temp_sensor
                 except Exception as e:
                     logging.error(f"Failed to change Left sensor addr: {e}.")
@@ -304,9 +303,8 @@ if __name__ == "__main__":
         while True:
             distances = tof.get_distances()
             print(
-                f"Left: {
-                    distances['left']} mm, " f"Right: {
-                    distances['right']} mm")
+                f"Left: {distances['left']} mm, Right: {distances['right']} mm"
+            )
             time.sleep(1)
     except KeyboardInterrupt:
         print("Stopped by user")


### PR DESCRIPTION
## Summary
- fix string formatting in `VL53L0XSensors`

## Testing
- `python -m py_compile src/mower/hardware/tof.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683da5db861c8322994148ef2a2f7692