### PR TITLE
Add requirements file for Ubuntu 24.04

### DIFF
--- a/requirements-ubuntu2404.txt
+++ b/requirements-ubuntu2404.txt
@@ -1,0 +1,92 @@
+# Ubuntu 24.04 Specific Requirements for Autonomous Mower Project
+
+# This file is intended for setting up the project on an Ubuntu 24.04 system.
+# It excludes Raspberry Pi-specific hardware libraries and uses full TensorFlow.
+# For Raspberry Pi, refer to the primary requirements.txt and installation scripts.
+
+# --------------------
+# Core Dependencies
+# --------------------
+numpy>=2.2.6
+opencv-python>=4.8.1.78
+Pillow>=10.3.0
+PyYAML>=6.0.2
+python-dotenv>=1.1.0
+Flask>=3.0.0
+Flask-SocketIO>=5.5.1
+geopy>=2.1.0
+imutils>=0.5.4
+networkx>=2.6.0
+pathfinding>=1.0.0
+Rtree>=1.0.0
+Shapely>=2.0.7
+tensorflow>=2.15.0  # Using full TensorFlow for general Ubuntu systems
+colorama>=0.4.4
+watchdog>=5.0.0
+ultralytics>=8.1.0
+onnx>=1.15.0
+onnxruntime>=1.16.0
+psutil>=7.0.0
+systemd-python>=234; sys_platform == "linux"  # For systemd integration on Linux
+python-daemon>=3.0.1
+supervisor>=4.2.5  # For process management
+prometheus_client>=0.17.0
+pynmea2>=1.18.0  # For parsing NMEA GPS data
+utm>=0.7.0  # For UTM coordinate conversions
+safety>=3.2.14  # For checking installed dependencies for known security vulnerabilities
+bandit>=1.7.5  # For finding common security issues in Python code
+pyOpenSSL>=23.0.0
+certifi>=2024.7.4
+grafana-client>=2.3.0; sys_platform == "linux" # Optional: if using Grafana for monitoring
+statsd>=4.0.1
+aiofiles>=23.0.0  # For asynchronous file operations
+aiohttp>=3.9.0  # For asynchronous HTTP requests
+setuptools>=69.0.0
+wheel>=0.42.0
+
+# -------------------------
+# Development Dependencies
+# -------------------------
+pytest>=8.3.5
+pytest-cov>=6.1.1
+pytest-mock>=3.12.0
+pytest-asyncio>=1.0.0
+pytest-timeout>=2.2.0
+pytest-xdist>=3.6.1
+black>=25.1.0  # Code formatter
+flake8>=3.9.2  # Linter
+mypy>=1.16.0  # Static type checker
+pylint>=3.0.0  # Linter
+isort>=5.13.0  # Import sorter
+coverage[toml]>=7.4.1  # Test coverage reporting
+tox>=4.15.0  # Test automation
+Sphinx>=7.4.7  # Documentation generator
+sphinx-rtd-theme>=2.0.0  # Theme for Sphinx
+pre-commit>=3.6.0  # For managing pre-commit hooks
+Flask-Cors>=5.0.1  # For handling Cross-Origin Resource Sharing in Flask
+scipy>=1.10.1  # Scientific computing library
+pydantic>=2.11.5  # Data validation
+Flask-Babel==4.0.0  # For Flask internationalization/localization
+
+# --------------------
+# Notes & System Setup
+# --------------------
+# 1. It is highly recommended to use a Python virtual environment:
+#    python3 -m venv .venv
+#    source .venv/bin/activate
+#    pip install -r requirements-ubuntu2404.txt
+#
+# 2. Some packages may require system-level build tools. On Ubuntu, install them via:
+#    sudo apt-get update && sudo apt-get install -y python3-dev build-essential pkg-config
+#
+# 3. If using specific hardware (like Coral TPUs) or system services (like gpsd),
+#    additional apt packages and configuration might be needed. Refer to the
+#    original install_requirements.sh and project documentation for guidance
+#    on those specialized setups. For example, for GDAL support (often a
+#    dependency for geospatial libraries that might be pulled transitively):
+#    sudo apt-get install -y libgdal-dev gdal-bin python3-gdal
+#
+# 4. The numpy<2.0.0 constraint present in some project files (for older Pi compatibility)
+#    has been relaxed here. If you encounter issues with libraries like OpenCV or
+#    TensorFlow, you might need to constrain numpy to an earlier version, e.g., numpy~=1.26.0
+#


### PR DESCRIPTION
This commit introduces `requirements-ubuntu2404.txt`, a specialized requirements file tailored for setting up your project on an Ubuntu 24.04 system.

Key changes from the Raspberry Pi-centric requirements:
- Excludes Raspberry Pi-specific hardware libraries (e.g., RPi.GPIO, Adafruit CircuitPython libraries for specific sensors).
- Replaces `tflite-runtime` with the full `tensorflow` package for more general ML capabilities on systems with more resources.
- Uses `opencv-python` instead of `opencv-python-headless`.
- Adjusts version constraints and includes notes on system setup, virtual environments, and potential dependency considerations (e.g., for NumPy).

This file aims to provide a cleaner dependency set for you when developing or deploying on Ubuntu 24.04, while the original `requirements.txt` and installation scripts remain focused on the Raspberry Pi target.