### PR TITLE
Fix split f-string bugs

### DIFF
--- a/src/mower/diagnostics/system_health.py
+++ b/src/mower/diagnostics/system_health.py
@@ -30,18 +30,17 @@ Example usage:
 import argparse
 import json
 import os
-import psutil
 import subprocess
 import sys
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
+
+import psutil
 
 # Import hardware test suite
-from mower.diagnostics.hardware_test import (
-    initialize_resource_manager,
-)
+from mower.diagnostics.hardware_test import initialize_resource_manager
 from mower.utilities.logger_config import LoggerConfigInfo
 
 # Configure logging
@@ -122,10 +121,7 @@ class SystemHealth:
                 issues.append(f"Critical memory usage: {memory_percent}%")
             if disk_percent > CRITICAL_DISK_THRESHOLD:
                 issues.append(f"Critical disk usage: {disk_percent}%")
-            if (
-                cpu_temp is not None
-                and cpu_temp > CRITICAL_TEMPERATURE_THRESHOLD
-            ):
+            if cpu_temp is not None and cpu_temp > CRITICAL_TEMPERATURE_THRESHOLD:
                 issues.append(f"Critical CPU temperature: {cpu_temp}°C")
 
             # Create system health report
@@ -233,9 +229,7 @@ class SystemHealth:
                         "status": "error",
                         "error": "IMU not available or not returning data",
                     }
-                    issues.append(
-                        "IMU sensor not available or not returning data"
-                    )
+                    issues.append("IMU sensor not available or not returning data")
             except Exception as e:
                 hardware_health["imu"] = {"status": "error", "error": str(e)}
                 issues.append(f"IMU sensor error: {str(e)}")
@@ -266,9 +260,7 @@ class SystemHealth:
                         issues.append(f"Low battery: {battery_percent}%")
                     elif battery_percent < 30:
                         status = "warning"
-                        issues.append(
-                            f"Battery level low: {battery_percent}%"
-                        )
+                        issues.append(f"Battery level low: {battery_percent}%")
 
                     hardware_health["battery"] = {
                         "status": status,
@@ -283,7 +275,8 @@ class SystemHealth:
             except Exception as e:
                 hardware_health["battery"] = {
                     "status": "error",
-                    "error": str(e), }
+                    "error": str(e),
+                }
                 issues.append(f"Battery monitor error: {str(e)}")
 
             # Check motors and other components
@@ -299,10 +292,10 @@ class SystemHealth:
                             hardware_health[component] = {"status": "ok"}
                         else:
                             hardware_health[component] = {
-                                "status": "error", "error": f"{component} controller not available", }
-                            issues.append(
-                                f"{component} controller not available"
-                            )
+                                "status": "error",
+                                "error": f"{component} controller not available",
+                            }
+                            issues.append(f"{component} controller not available")
                 except Exception as e:
                     hardware_health[component] = {
                         "status": "error",
@@ -415,9 +408,7 @@ class SystemHealth:
                             "crash_count": crash_count,
                             "error": f"High number of errors: {error_count}",
                         }
-                        issues.append(
-                            f"High number of errors in logs: {error_count}"
-                        )
+                        issues.append(f"High number of errors in logs: {error_count}")
                     else:
                         software_health["logs"] = {
                             "status": "ok",
@@ -470,7 +461,7 @@ class SystemHealth:
             List[str]: List of recommendations.
         """
         recommendations = []
-        issues = self.health_status["issues"]        # System recommendations
+        issues = self.health_status["issues"]  # System recommendations
         if any("Critical CPU usage" in issue for issue in issues):
             recommendations.append(
                 "Reduce CPU load by disabling non-essential services or "
@@ -480,9 +471,7 @@ class SystemHealth:
             recommendations.append(
                 "Free up memory by restarting the mower service or the entire system"
             )
-        if any(
-            "Critical disk usage" in issue for issue in issues
-        ):
+        if any("Critical disk usage" in issue for issue in issues):
             recommendations.append(
                 "Free up disk space by removing old logs or unnecessary files"
             )
@@ -493,9 +482,7 @@ class SystemHealth:
 
         # Hardware recommendations
         if any("IMU sensor" in issue for issue in issues):
-            recommendations.append(
-                "Check IMU sensor connections and configuration"
-            )
+            recommendations.append("Check IMU sensor connections and configuration")
         if any("GPS not" in issue for issue in issues):
             recommendations.append(
                 "Move to an area with better GPS reception or check GPS antenna"
@@ -515,7 +502,7 @@ class SystemHealth:
         if any("Camera" in issue for issue in issues):
             recommendations.append(
                 "Check camera connections and configuration"
-            )        # Software recommendations
+            )  # Software recommendations
         if any("Mower service not running" in issue for issue in issues):
             recommendations.append(
                 "Start the mower service with: "
@@ -525,9 +512,7 @@ class SystemHealth:
             recommendations.append(
                 "Check error logs for crash details and consider updating software"
             )
-        if any(
-            "High number of errors" in issue for issue in issues
-        ):
+        if any("High number of errors" in issue for issue in issues):
             recommendations.append(
                 "Review error logs to identify and fix recurring issues"
             )
@@ -615,9 +600,7 @@ class SystemHealth:
             # List all health reports
             reports = []
             for filename in os.listdir(HEALTH_REPORT_DIR):
-                if filename.startswith(
-                    "health_report_"
-                ) and filename.endswith(".json"):
+                if filename.startswith("health_report_") and filename.endswith(".json"):
                     filepath = os.path.join(HEALTH_REPORT_DIR, filename)
                     reports.append((filepath, os.path.getmtime(filepath)))
 
@@ -643,9 +626,7 @@ class SystemHealth:
             callback: Function to call with health status after each check.
         """
         try:
-            logger.info(
-                f"Starting health monitoring with interval {interval} seconds"
-            )
+            logger.info(f"Starting health monitoring with interval {interval} seconds")
             while True:
                 # Run a full health check
                 health_status = self.run_full_health_check()
@@ -657,12 +638,10 @@ class SystemHealth:
                 # Log critical issues
                 if health_status["status"] == "critical":
                     logger.critical(
-                        f"Critical health issues detected: {
-                            health_status['issues']}")
-                elif health_status["status"] == "error":
-                    logger.error(
-                        f"Health errors detected: {health_status['issues']}"
+                        f"Critical health issues detected: {health_status['issues']}"
                     )
+                elif health_status["status"] == "error":
+                    logger.error(f"Health errors detected: {health_status['issues']}")
                 elif health_status["status"] == "warning":
                     logger.warning(
                         f"Health warnings detected: {health_status['issues']}"
@@ -731,9 +710,7 @@ def main():
         "--output",
         choices=["text", "json"],
         default="text",
-        help=(
-            "Output format (default: text)"
-        ),
+        help=("Output format (default: text)"),
     )
 
     args = parser.parse_args()
@@ -756,19 +733,14 @@ def main():
                     f"AUTONOMOUS MOWER HEALTH REPORT - "
                     f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
                 )
-                print("=" * 80)
                 print(
-                    f"Overall Status: {
-                        health_status.get(
-                            'status',
-                            'unknown').upper()}")
+                    f"Overall Status: {health_status.get('status', 'unknown').upper()}"
+                )
                 print("\nIssues:")
                 for issue in health_status.get("issues", []):
                     print(f"  - {issue}")
                 print("\nRecommendations:")
-                for recommendation in health_status.get(
-                    "recommendations", []
-                ):
+                for recommendation in health_status.get("recommendations", []):
                     print(f"  - {recommendation}")
                 print("=" * 80)
 
@@ -791,12 +763,11 @@ def main():
                 print(
                     (
                         f"AUTONOMOUS MOWER {args.check.upper()} HEALTH"
-                        f" CHECK - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+                        f" CHECK - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                    )
                 )
                 print("=" * 80)
-                print(
-                    f"Status: {result.get('status', 'unknown').upper()}"
-                )
+                print(f"Status: {result.get('status', 'unknown').upper()}")
                 if "issues" in result:
                     print("\nIssues:")
                     for issue in result["issues"]:

--- a/src/mower/hardware/serial_port.py
+++ b/src/mower/hardware/serial_port.py
@@ -2,7 +2,7 @@ import os
 import platform
 import threading
 import time
-from typing import Tuple, Any
+from typing import Any, Tuple
 
 import serial
 import serial.tools.list_ports
@@ -85,9 +85,7 @@ class SerialPort:
             # For now, let's re-raise to make startup failure explicit
             raise
         except Exception as e:
-            logger.error(
-                f"Unexpected error opening serial port {
-                    self.port}: {e}")
+            logger.error(f"Unexpected error opening serial port {self.port}: {e}")
             self.ser = None
             raise
         return self
@@ -103,17 +101,11 @@ class SerialPort:
             except serial.SerialException as e:
                 logger.error(f"SerialException closing port {self.port}: {e}")
             except Exception as e:
-                logger.error(
-                    f"Unexpected error closing serial port {
-                        self.port}: {e}")
+                logger.error(f"Unexpected error closing serial port {self.port}: {e}")
         elif self.ser is None:
-            logger.debug(
-                f"Serial port {
-                    self.port} was already None, nothing to close.")
+            logger.debug(f"Serial port {self.port} was already None, nothing to close.")
         else:  # Not None but not open
-            logger.debug(
-                f"Serial port {
-                    self.port} was not open, nothing to close.")
+            logger.debug(f"Serial port {self.port} was not open, nothing to close.")
         return self
 
     @staticmethod
@@ -201,25 +193,23 @@ class SerialPort:
 
         try:
             # Check buffer first for a complete line
-            if '\n' in self.data_buffer:
-                line, self.data_buffer = self.data_buffer.split('\n', 1)
-                return (True, line + '\n')
+            if "\n" in self.data_buffer:
+                line, self.data_buffer = self.data_buffer.split("\n", 1)
+                return (True, line + "\n")
 
             # Read new data if buffer doesn't have a complete line
             if self.ser.in_waiting > 0:
                 new_data = self.ser.read(self.ser.in_waiting).decode(
-                    self.charset, errors='ignore'
+                    self.charset, errors="ignore"
                 )
                 self.data_buffer += new_data
-                if '\n' in self.data_buffer:
-                    line, self.data_buffer = self.data_buffer.split('\n', 1)
-                    return (True, line + '\n')
+                if "\n" in self.data_buffer:
+                    line, self.data_buffer = self.data_buffer.split("\n", 1)
+                    return (True, line + "\n")
             return (False, "")  # No complete line found yet
 
         except (serial.serialutil.SerialException, TypeError, UnicodeDecodeError) as e:
-            logger.warning(
-                f"Failed reading line from serial port {
-                    self.port}: {e}")
+            logger.warning(f"Failed reading line from serial port {self.port}: {e}")
             return (False, "")
 
     def get_parsed_data(self, parser_function) -> Tuple[bool, Any]:
@@ -258,11 +248,7 @@ class SerialLineReader:
 
     _instance = None
 
-    def __init__(
-            self,
-            serial: SerialPort,
-            max_lines: int = 0,
-            debug: bool = False):
+    def __init__(self, serial: SerialPort, max_lines: int = 0, debug: bool = False):
         self.serial = serial
         self.max_lines = max_lines
         self.debug = debug
@@ -387,8 +373,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.samples < 0:
-        print("Samples per read cycle,"
-              "greater than zero OR zero for unlimited")
+        print("Samples per read cycle," "greater than zero OR zero for unlimited")
         parser.print_help()
         sys.exit(0)
 
@@ -409,8 +394,7 @@ if __name__ == "__main__":
         )
 
         if args.threaded:
-            update_thread = threading.Thread(
-                target=line_reader.update, args=())
+            update_thread = threading.Thread(target=line_reader.update, args=())
             update_thread.start()
 
         def read_lines():

--- a/src/mower/navigation/path_planner.py
+++ b/src/mower/navigation/path_planner.py
@@ -7,13 +7,13 @@ different mowing patterns and learning-based optimization.
 
 import json
 import os  # Added for environment variables
-import requests  # Added for API calls
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import List, Tuple, Optional, Dict, Any  # Added Dict and Any
+from typing import Any, Dict, List, Optional, Tuple  # Added Dict and Any
 
 import numpy as np
+import requests  # Added for API calls
 
 from mower.utilities.logger_config import LoggerConfigInfo
 
@@ -106,9 +106,7 @@ class PathPlanner:
                 self.learning_config
                 and np.random.random() < self.learning_config.exploration_rate
             ):
-                self.pattern_config.pattern_type = np.random.choice(
-                    list(
-                        PatternType))
+                self.pattern_config.pattern_type = np.random.choice(list(PatternType))
             elif self.learning_config:
                 state = self._get_current_state()
                 self.pattern_config.pattern_type = self._get_best_action(state)
@@ -125,10 +123,8 @@ class PathPlanner:
                 elevation_data = get_elevation_for_path(path)
 
             reward = self._calculate_reward(path, elevation_data)
-            self._update_q_table(
-                state, self.pattern_config.pattern_type, reward)
-            self._store_experience(
-                state, self.pattern_config.pattern_type, reward)
+            self._update_q_table(state, self.pattern_config.pattern_type, reward)
+            self._store_experience(state, self.pattern_config.pattern_type, reward)
 
             if self.step_count % self.learning_config.update_frequency == 0:
                 self._update_model()
@@ -158,14 +154,14 @@ class PathPlanner:
                 PatternType.DIAMOND: self._generate_diamond_path,
                 PatternType.WAVES: self._generate_waves_path,
                 PatternType.CONCENTRIC: self._generate_concentric_path,
-                PatternType.CUSTOM: self._generate_custom_path, }
+                PatternType.CUSTOM: self._generate_custom_path,
+            }
 
-            generator = pattern_generators.get(
-                self.pattern_config.pattern_type)
+            generator = pattern_generators.get(self.pattern_config.pattern_type)
             if not generator:
                 logger.error(
-                    "Unknown pattern type: %s",
-                    self.pattern_config.pattern_type)
+                    "Unknown pattern type: %s", self.pattern_config.pattern_type
+                )
                 return []
 
             return generator()
@@ -204,8 +200,7 @@ class PathPlanner:
 
             # Calculate number of passes
             width = max_proj - min_proj
-            spacing = self.pattern_config.spacing * \
-                (1 - self.pattern_config.overlap)
+            spacing = self.pattern_config.spacing * (1 - self.pattern_config.overlap)
             num_passes = int(np.ceil(width / spacing))
 
             # Generate pass lines
@@ -228,8 +223,7 @@ class PathPlanner:
             logger.error("Error generating parallel path - value error: %s", e)
             return []
         except (TypeError, IndexError) as e:
-            logger.error(
-                "Error generating parallel path - type/index error: %s", e)
+            logger.error("Error generating parallel path - type/index error: %s", e)
             return []
         except Exception as e:
             logger.error("Unexpected error generating parallel path: %s", e)
@@ -264,8 +258,7 @@ class PathPlanner:
                 path.extend(zip(x, y))
 
                 # Increase radius
-                r += self.pattern_config.spacing * (
-                    1 - self.pattern_config.overlap)
+                r += self.pattern_config.spacing * (1 - self.pattern_config.overlap)
 
             return path
 
@@ -273,8 +266,7 @@ class PathPlanner:
             logger.error("Error generating spiral path - value error: %s", e)
             return []
         except (TypeError, IndexError) as e:
-            logger.error(
-                "Error generating spiral path - type/index error: %s", e)
+            logger.error("Error generating spiral path - type/index error: %s", e)
             return []
         except (RuntimeError, AttributeError) as e:
             logger.error("Error generating spiral path - runtime error: %s", e)
@@ -295,8 +287,7 @@ class PathPlanner:
 
             # Calculate number of passes
             width = max_proj - min_proj
-            spacing = self.pattern_config.spacing * \
-                (1 - self.pattern_config.overlap)
+            spacing = self.pattern_config.spacing * (1 - self.pattern_config.overlap)
             num_passes = int(np.ceil(width / spacing))
 
             # Generate zigzag points
@@ -326,8 +317,7 @@ class PathPlanner:
             logger.error("Error generating zigzag path - value error: %s", e)
             return []
         except (TypeError, IndexError) as e:
-            logger.error(
-                "Error generating zigzag path - type/index error: %s", e)
+            logger.error("Error generating zigzag path - type/index error: %s", e)
             return []
         except (RuntimeError, AttributeError) as e:
             logger.error("Error generating zigzag path - runtime error: %s", e)
@@ -348,16 +338,13 @@ class PathPlanner:
             return horizontal + vertical
 
         except ValueError as e:
-            logger.error(
-                "Error generating checkerboard path - value error: %s", e)
+            logger.error("Error generating checkerboard path - value error: %s", e)
             return []
         except (TypeError, IndexError) as e:
-            logger.error(
-                "Error generating checkerboard path - type/index error: %s", e)
+            logger.error("Error generating checkerboard path - type/index error: %s", e)
             return []
         except (RuntimeError, AttributeError) as e:
-            logger.error(
-                "Error generating checkerboard path - runtime error: %s", e)
+            logger.error("Error generating checkerboard path - runtime error: %s", e)
             return []
 
     def _generate_diamond_path(self) -> List[Tuple[float, float]]:
@@ -377,12 +364,10 @@ class PathPlanner:
             logger.error("Error generating diamond path - value error: %s", e)
             return []
         except (TypeError, IndexError) as e:
-            logger.error(
-                "Error generating diamond path - type/index error: %s", e)
+            logger.error("Error generating diamond path - type/index error: %s", e)
             return []
         except (RuntimeError, AttributeError) as e:
-            logger.error(
-                "Error generating diamond path - runtime error: %s", e)
+            logger.error("Error generating diamond path - runtime error: %s", e)
             return []
 
     def _generate_waves_path(self) -> List[Tuple[float, float]]:
@@ -404,8 +389,7 @@ class PathPlanner:
 
             while y <= max_y:
                 x_points = np.linspace(min_x, max_x, 100)
-                y_points = y + amplitude * np.sin(
-                    2 * np.pi * x_points / wave_length)
+                y_points = y + amplitude * np.sin(2 * np.pi * x_points / wave_length)
 
                 # Add points that fall within boundary
                 for x, wave_y in zip(x_points, y_points):
@@ -421,8 +405,7 @@ class PathPlanner:
             logger.error("Error generating waves path - value error: %s", e)
             return []
         except (TypeError, IndexError) as e:
-            logger.error(
-                "Error generating waves path - type/index error: %s", e)
+            logger.error("Error generating waves path - type/index error: %s", e)
             return []
         except (RuntimeError, AttributeError) as e:
             logger.error("Error generating waves path - runtime error: %s", e)
@@ -459,22 +442,18 @@ class PathPlanner:
                     if self._point_in_polygon(point, boundary):
                         path.append((px, py))
 
-                r -= self.pattern_config.spacing * (
-                    1 - self.pattern_config.overlap)
+                r -= self.pattern_config.spacing * (1 - self.pattern_config.overlap)
 
             return path
 
         except ValueError as e:
-            logger.error(
-                "Error generating concentric path - value error: %s", e)
+            logger.error("Error generating concentric path - value error: %s", e)
             return []
         except (TypeError, IndexError) as e:
-            logger.error(
-                "Error generating concentric path - type/index error: %s", e)
+            logger.error("Error generating concentric path - type/index error: %s", e)
             return []
         except (RuntimeError, AttributeError) as e:
-            logger.error(
-                "Error generating concentric path - runtime error: %s", e)
+            logger.error("Error generating concentric path - runtime error: %s", e)
             return []
 
     def _generate_custom_path(self) -> List[Tuple[float, float]]:
@@ -502,23 +481,20 @@ class PathPlanner:
 
             # Sort intersections by distance from start
             if intersections:
-                intersections.sort(
-                    key=lambda p: np.linalg.norm(
-                        np.array(p) - start))
+                intersections.sort(key=lambda p: np.linalg.norm(np.array(p) - start))
 
             return intersections
 
         except ValueError as e:
-            logger.error(
-                "Error finding boundary intersections - value error: %s", e)
+            logger.error("Error finding boundary intersections - value error: %s", e)
             return []
         except (TypeError, IndexError) as e:
             logger.error(
-                "Error finding boundary intersections - type/index error: %s", e)
+                "Error finding boundary intersections - type/index error: %s", e
+            )
             return []
         except (RuntimeError, AttributeError) as e:
-            logger.error(
-                "Error finding boundary intersections - runtime error: %s", e)
+            logger.error("Error finding boundary intersections - runtime error: %s", e)
             return []
 
     def _line_intersection(
@@ -557,22 +533,18 @@ class PathPlanner:
             return None
 
         except ValueError as e:
-            logger.error(
-                "Error calculating line intersection - value error: %s", e)
+            logger.error("Error calculating line intersection - value error: %s", e)
             return None
         except (TypeError, IndexError) as e:
             logger.error(
-                "Error calculating line intersection - type/index error: %s", e)
+                "Error calculating line intersection - type/index error: %s", e
+            )
             return None
         except (ZeroDivisionError, RuntimeError) as e:
-            logger.error(
-                "Error calculating line intersection - runtime error: %s", e)
+            logger.error("Error calculating line intersection - runtime error: %s", e)
             return None
 
-    def _point_in_polygon(
-            self,
-            point: np.ndarray,
-            polygon: np.ndarray) -> bool:
+    def _point_in_polygon(self, point: np.ndarray, polygon: np.ndarray) -> bool:
         """Check if a point is inside a polygon."""
         x, y = point
         n = len(polygon)
@@ -592,8 +564,7 @@ class PathPlanner:
 
         return inside
 
-    def update_obstacle_map(
-            self, obstacles: List[Tuple[float, float]]) -> None:
+    def update_obstacle_map(self, obstacles: List[Tuple[float, float]]) -> None:
         """Update the obstacle map."""
         self.obstacles = obstacles
 
@@ -631,8 +602,10 @@ class PathPlanner:
             return PatternType.PARALLEL
 
     def _calculate_reward(
-            self, path: List[Tuple[float, float]],
-            elevation_data: Optional[List[float]] = None) -> float:
+        self,
+        path: List[Tuple[float, float]],
+        elevation_data: Optional[List[float]] = None,
+    ) -> float:
         """Calculate reward based on path quality and elevation data."""
         if not path:
             return -100.0  # Penalize empty paths heavily
@@ -658,8 +631,7 @@ class PathPlanner:
                 )
                 # Avoid division by zero for very short segments
                 if distance_segment > 1e-6:
-                    elevation_diff = abs(
-                        elevation_data[i + 1] - elevation_data[i])
+                    elevation_diff = abs(elevation_data[i + 1] - elevation_data[i])
                     slope = elevation_diff / distance_segment
 
                     # Penalize based on absolute elevation change
@@ -678,8 +650,7 @@ class PathPlanner:
 
         return max(0.0, min(1.0, reward))
 
-    def _calculate_path_distance(
-            self, path: List[Tuple[float, float]]) -> float:
+    def _calculate_path_distance(self, path: List[Tuple[float, float]]) -> float:
         """Calculate total distance of path."""
         try:
             if len(path) < 2:
@@ -740,8 +711,7 @@ class PathPlanner:
                 v2 = p3 - p2
 
                 # Calculate angle between vectors
-                cos_angle = np.dot(
-                    v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+                cos_angle = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
                 angle = np.arccos(np.clip(cos_angle, -1.0, 1.0))
                 angles.append(angle)
 
@@ -754,11 +724,7 @@ class PathPlanner:
             logger.error(f"Error calculating smoothness: {e}")
             return 0.0
 
-    def _update_q_table(
-            self,
-            state: str,
-            action: PatternType,
-            reward: float) -> None:
+    def _update_q_table(self, state: str, action: PatternType, reward: float) -> None:
         """Update Q-table with new experience."""
         try:
             if state not in self.q_table:
@@ -769,24 +735,17 @@ class PathPlanner:
 
             # Calculate new Q-value
             next_state = self._get_current_state()
-            max_next_q = max(
-                self.q_table.get(
-                    next_state,
-                    {}).values(),
-                default=0.0)
+            max_next_q = max(self.q_table.get(next_state, {}).values(), default=0.0)
             new_q = current_q + self.learning_config.learning_rate * (
-                reward + self.learning_config.discount_factor * max_next_q - current_q)
+                reward + self.learning_config.discount_factor * max_next_q - current_q
+            )
 
             # Update Q-table
             self.q_table[state][action] = new_q
         except Exception as e:
             logger.error(f"Error updating Q-table: {e}")
 
-    def _store_experience(
-            self,
-            state: str,
-            action: PatternType,
-            reward: float) -> None:
+    def _store_experience(self, state: str, action: PatternType, reward: float) -> None:
         """Store experience in replay buffer."""
         try:
             experience = {
@@ -959,18 +918,15 @@ class PathPlanner:
             ]
 
             logger.info(
-                f"Boundary points updated: {
-                    self.pattern_config.boundary_points}")
-            return True
+                f"Boundary points updated: {self.pattern_config.boundary_points}"
+            )
         except Exception as e:
             logger.error(f"Error setting boundary points: {e}")
             return False
 
 
 # --- Elevation API Function ---
-def get_elevation_for_path(
-    path: List[Tuple[float, float]]
-) -> Optional[List[float]]:
+def get_elevation_for_path(path: List[Tuple[float, float]]) -> Optional[List[float]]:
     """Fetch elevation data for a given path using Google Maps Elevation API."""
     if not GOOGLE_MAPS_API_KEY:
         logger.warning("GOOGLE_MAPS_API_KEY not set. Cannot fetch elevation.")

--- a/src/mower/utilities/backup_restore.py
+++ b/src/mower/utilities/backup_restore.py
@@ -33,12 +33,12 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 import time
 from datetime import datetime
-import tempfile
 
 # from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Any, Dict, List, Optional, Tuple
 
 # Import logger
 from mower.utilities.logger_config import LoggerConfigInfo
@@ -72,8 +72,7 @@ class BackupRestore:
         """
         self.backup_dir = backup_dir
         os.makedirs(self.backup_dir, exist_ok=True)
-        self.manifest_file = os.path.join(
-            self.backup_dir, BACKUP_MANIFEST_FILE)
+        self.manifest_file = os.path.join(self.backup_dir, BACKUP_MANIFEST_FILE)
         self._load_manifest()
 
     def _load_manifest(self) -> None:
@@ -83,9 +82,7 @@ class BackupRestore:
                 with open(self.manifest_file, "r") as f:
                     self.manifest = json.load(f)
             except json.JSONDecodeError:
-                logger.error(
-                    f"Error parsing manifest file: {
-                        self.manifest_file}")
+                logger.error(f"Error parsing manifest file: {self.manifest_file}")
                 self.manifest = {"backups": []}
         else:
             self.manifest = {"backups": []}
@@ -208,9 +205,7 @@ class BackupRestore:
             return
 
         # Sort backups by creation time (oldest first)
-        sorted_backups = sorted(
-            self.manifest["backups"],
-            key=lambda x: x["created_at"])
+        sorted_backups = sorted(self.manifest["backups"], key=lambda x: x["created_at"])
 
         # Remove oldest backups
         backups_to_remove = sorted_backups[: len(sorted_backups) - MAX_BACKUPS]
@@ -266,8 +261,7 @@ class BackupRestore:
 
             # Skip if source directory doesn't exist
             if not os.path.exists(source_dir):
-                logger.warning(
-                    f"Source directory {source_dir} not found, skipping")
+                logger.warning(f"Source directory {source_dir} not found, skipping")
                 continue
 
             # Create tarball
@@ -284,10 +278,11 @@ class BackupRestore:
 
         # Add backup to manifest
         backup_info = {
-            "id": backup_id, "created_at": datetime.now().isoformat(),
+            "id": backup_id,
+            "created_at": datetime.now().isoformat(),
             "components": successful_components,
-            "description": description or
-            "Backup created by backup_restore.py", }
+            "description": description or "Backup created by backup_restore.py",
+        }
         self.manifest["backups"].append(backup_info)
         self._save_manifest()
 
@@ -339,8 +334,9 @@ class BackupRestore:
             # Validate components
             for component in components:
                 if component not in backup_info["components"]:
-                    error_msg = f"Component {component}  not found in backup {
-                        backup_id} "
+                    error_msg = (
+                        f"Component {component}  not found in backup {backup_id} "
+                    )
                     return (False, error_msg)
 
         # Stop services before restoring
@@ -483,8 +479,7 @@ class BackupRestore:
                 message: Information about the process or error message.
         """
         # Create a cron job to run the backup script
-        components_str = ",".join(
-            components) if components else "config,data,logs"
+        components_str = ",".join(components) if components else "config,data,logs"
         description_str = f'"{description}"' if description else '""'
 
         cron_command = (
@@ -649,8 +644,9 @@ def main():
 
             print(f"Found {len(backups)} backups:")
             for backup in backups:
-                created_at = datetime.fromisoformat(
-                    backup["created_at"]).strftime("%Y-%m-%d %H:%M:%S")
+                created_at = datetime.fromisoformat(backup["created_at"]).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
                 print(f"ID: {backup['id']}")
                 print(f"  Created: {created_at}")
                 print(f"  Components: {', '.join(backup['components'])}")
@@ -664,8 +660,9 @@ def main():
                 print(f"Backup {args.info} not found")
                 return 1
 
-            created_at = datetime.fromisoformat(
-                backup_info["created_at"]).strftime("%Y-%m-%d %H:%M:%S")
+            created_at = datetime.fromisoformat(backup_info["created_at"]).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
             print(f"Backup ID: {backup_info['id']}")
             print(f"Created: {created_at}")
             print(f"Components: {', '.join(backup_info['components'])}")
@@ -673,10 +670,7 @@ def main():
 
             # Check if the backup is valid
             is_valid = backup_restore._verify_backup(args.info)
-            print(
-                f"Status: {
-                    'Valid' if is_valid else 'Invalid or incomplete'}")
-
+            print(f"Status: {'Valid' if is_valid else 'Invalid or incomplete'}")
             return 0
 
         elif args.delete:

--- a/src/mower/utilities/database_optimizer.py
+++ b/src/mower/utilities/database_optimizer.py
@@ -5,12 +5,12 @@ This module provides tools for optimizing database operations
 by implementing batching, connection pooling, and query optimization.
 """
 
-import time
-import threading
 import functools
 import sqlite3
-from typing import Dict, Any, List, Optional, Callable, Tuple, Union
+import threading
+import time
 from queue import Queue
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from mower.utilities.logger_config import LoggerConfigInfo
 
@@ -63,8 +63,8 @@ class ConnectionPool:
                 self.active_connections += 1
 
             logger.debug(
-                f"Created new database connection (total: {
-                    self.active_connections})")
+                f"Created new database connection (total: {self.active_connections})"
+            )
         except Exception as e:
             logger.error(f"Error creating database connection: {e}")
 
@@ -88,8 +88,7 @@ class ConnectionPool:
             else:
                 # If we've reached the maximum number of connections,
                 # wait for one to become available
-                logger.warning(
-                    "Connection pool exhausted, waiting for a connection")
+                logger.warning("Connection pool exhausted, waiting for a connection")
                 return self.connections.get()
 
     def return_connection(self, conn: sqlite3.Connection):
@@ -171,8 +170,7 @@ class BatchProcessor:
         self.delete_batches = {}
         self.lock = threading.Lock()
 
-        logger.info(
-            f"Batch processor initialized with batch size {batch_size}")
+        logger.info(f"Batch processor initialized with batch size {batch_size}")
 
     def add_insert(self, table: str, data: Dict[str, Any]):
         """
@@ -260,9 +258,7 @@ class BatchProcessor:
         # Execute the batch
         self._execute_batch(query, params)
 
-        logger.debug(
-            f"Processed batch of {
-                len(batch)} inserts for table {table}")
+        logger.debug(f"Processed batch of {len(batch)} inserts for table {table}")
 
     def _process_update_batch(self, table: str):
         """
@@ -301,10 +297,7 @@ class BatchProcessor:
             if self.auto_commit:
                 conn.commit()
 
-            logger.debug(
-                f"Processed batch of {
-                    len(batch)} updates for table {table}")
-        except Exception as e:
+            logger.debug(f"Processed batch of {len(batch)} updates for table {table}")
             logger.error(f"Error processing update batch: {e}")
             conn.rollback()
         finally:
@@ -342,11 +335,7 @@ class BatchProcessor:
             if self.auto_commit:
                 conn.commit()
 
-            logger.debug(
-                f"Processed batch of {
-                    len(batch)} deletes for table {table}")
-        except Exception as e:
-            logger.error(f"Error processing delete batch: {e}")
+            logger.debug(f"Processed batch of {len(batch)} deletes for table {table}")
             conn.rollback()
         finally:
             # Return the connection to the pool
@@ -515,9 +504,8 @@ class QueryOptimizer:
                     self.query_cache[cache_key] = results
 
             logger.debug(
-                f"Executed query in {
-                    execution_time:.4f} seconds: {optimized_query}")
-
+                f"Executed query in {execution_time:.4f} seconds: {optimized_query}"
+            )
             return results
         except Exception as e:
             logger.error(f"Error executing query: {e}")
@@ -526,8 +514,7 @@ class QueryOptimizer:
             # Return the connection to the pool
             self.connection_pool.return_connection(conn)
 
-    def get_slow_queries(
-            self, threshold: float = 0.1) -> Dict[str, Dict[str, float]]:
+    def get_slow_queries(self, threshold: float = 0.1) -> Dict[str, Dict[str, float]]:
         """
         Get statistics for slow queries.
 
@@ -562,11 +549,7 @@ class DatabaseOptimizer:
     by implementing connection pooling, batching, and query optimization.
     """
 
-    def __init__(
-            self,
-            db_path: str,
-            max_connections: int = 5,
-            batch_size: int = 100):
+    def __init__(self, db_path: str, max_connections: int = 5, batch_size: int = 100):
         """
         Initialize the database optimizer.
 
@@ -668,8 +651,7 @@ class DatabaseOptimizer:
             columns = list(data.keys())
             placeholders = ", ".join(["?"] * len(columns))
             column_str = ", ".join(columns)
-            query = f"INSERT INTO {table}  ({column_str}) VALUES ({
-                placeholders}) "
+            query = f"INSERT INTO {table}  ({column_str}) VALUES ({placeholders}) "
             params = tuple(data.values())
 
             # Get a connection
@@ -727,12 +709,7 @@ class DatabaseOptimizer:
                 # Return the connection to the pool
                 self.connection_pool.return_connection(conn)
 
-    def delete(
-            self,
-            table: str,
-            condition: str,
-            params: Tuple,
-            batch: bool = True):
+    def delete(self, table: str, condition: str, params: Tuple, batch: bool = True):
         """
         Delete data from a table.
 
@@ -790,8 +767,7 @@ class DatabaseOptimizer:
         """Clear the query cache."""
         self.query_optimizer.clear_cache()
 
-    def get_slow_queries(
-            self, threshold: float = 0.1) -> Dict[str, Dict[str, float]]:
+    def get_slow_queries(self, threshold: float = 0.1) -> Dict[str, Dict[str, float]]:
         """
         Get statistics for slow queries.
 
@@ -837,8 +813,7 @@ def get_database_optimizer(
     global _database_optimizer
 
     if _database_optimizer is None:
-        _database_optimizer = DatabaseOptimizer(
-            db_path, max_connections, batch_size)
+        _database_optimizer = DatabaseOptimizer(db_path, max_connections, batch_size)
 
     return _database_optimizer
 

--- a/src/mower/utilities/startup_optimizer.py
+++ b/src/mower/utilities/startup_optimizer.py
@@ -5,12 +5,12 @@ This module provides tools for optimizing the startup time of the application
 by implementing lazy loading, parallel initialization, and prioritized loading.
 """
 
-import time
-import threading
-import importlib
 import functools
-from typing import Dict, Any, List, Optional, Callable, Set, Tuple
+import importlib
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from mower.utilities.logger_config import LoggerConfigInfo
 
@@ -41,10 +41,7 @@ class LazyLoader:
         self.loaded = False
 
         logger.debug(
-            (
-                f"Created lazy loader for {module_path}{f'.{class_name}'"
-                f" if class_name else ''}"
-            )
+            f"Created lazy loader for {module_path}{f'.{class_name}' if class_name else ''}"
         )
 
     def __call__(self, *args, **kwargs):
@@ -75,9 +72,7 @@ class LazyLoader:
         self.module = importlib.import_module(self.module_path)
         self.loaded = True
         load_time = time.time() - start_time
-        logger.debug(
-            f"Lazy loaded {self.module_path} in {load_time:.4f} seconds"
-        )
+        logger.debug(f"Lazy loaded {self.module_path} in {load_time:.4f} seconds")
 
 
 class StartupOptimizer:
@@ -120,9 +115,7 @@ class StartupOptimizer:
         logger.debug(f"Registered lazy loader for {name}")
         return loader
 
-    def register_component_dependency(
-        self, component: str, depends_on: List[str]
-    ):
+    def register_component_dependency(self, component: str, depends_on: List[str]):
         """
         Register dependencies between components.
 
@@ -207,14 +200,10 @@ class StartupOptimizer:
 
         if parallel:
             # Initialize components in parallel
-            with ThreadPoolExecutor(
-                max_workers=self.thread_pool_size
-            ) as executor:
+            with ThreadPoolExecutor(max_workers=self.thread_pool_size) as executor:
                 # Submit initialization tasks
                 future_to_component = {
-                    executor.submit(
-                        self._initialize_component, component
-                    ): component
+                    executor.submit(self._initialize_component, component): component
                     for component in components
                 }
 
@@ -254,9 +243,7 @@ class StartupOptimizer:
         # Check if dependencies are initialized
         for dependency in self.component_dependencies.get(component, []):
             if dependency not in self.initialized_components:
-                logger.debug(
-                    f"Initializing dependency {dependency} for {component}"
-                )
+                logger.debug(f"Initializing dependency {dependency} for {component}")
                 self._initialize_component(dependency)
 
         # Initialize the component
@@ -267,9 +254,7 @@ class StartupOptimizer:
         self.initialization_times[component] = initialization_time
         self.initialized_components.add(component)
 
-        logger.info(
-            f"Initialized {component} in {initialization_time:.4f} seconds"
-        )
+        logger.info(f"Initialized {component} in {initialization_time:.4f} seconds")
         return instance
 
     def get_initialization_times(self) -> Dict[str, float]:
@@ -387,9 +372,7 @@ def optimize_startup():
         "NavigationController",
     )
 
-    optimizer.register_lazy_loader(
-        "web_ui", "mower.ui.web_ui.server", "WebServer"
-    )
+    optimizer.register_lazy_loader("web_ui", "mower.ui.web_ui.server", "WebServer")
 
     # Register component dependencies
     optimizer.register_component_dependency(
@@ -454,9 +437,7 @@ def measure_startup_time(func: Callable):
     result = func()
     execution_time = time.time() - start_time
 
-    logger.info(
-        f"Function {func.__name__} executed in {execution_time:.4f} seconds"
-    )
+    logger.info(f"Function {func.__name__} executed in {execution_time:.4f} seconds")
 
     return result, execution_time
 
@@ -473,6 +454,7 @@ def compare_startup_times():
     # Measure unoptimized startup time
     def unoptimized_startup():
         from mower.config_management.config_manager import ConfigManager
+        from mower.navigation.navigation import NavigationController
         from mower.navigation.path_planner import (
             PathPlanner,
             PatternConfig,
@@ -481,7 +463,6 @@ def compare_startup_times():
         from mower.obstacle_detection.obstacle_detector import (
             ObstacleDetector,
         )
-        from mower.navigation.navigation import NavigationController
 
         config_manager = ConfigManager()
 


### PR DESCRIPTION
### Summary
- repair f-string lines broken by formatting
- clean up database optimizer, startup loader and other utils

### Test Plan
- `pre-commit run --files src/mower/diagnostics/system_health.py src/mower/hardware/gpio_manager.py src/mower/hardware/serial_port.py src/mower/navigation/path_planner.py src/mower/utilities/backup_restore.py src/mower/utilities/database_optimizer.py src/mower/utilities/startup_optimizer.py`
- `python - <<'PY'
import os, ast
for root, dirs, files in os.walk('src'):
    if 'tests' in root.split(os.sep) or 'simulation' in root.split(os.sep):
        continue
    for f in files:
        if f.endswith('.py'):
            ast.parse(open(os.path.join(root,f)).read())
PY`

------
https://chatgpt.com/codex/tasks/task_e_683f5cca4ce083229b4d21e0f14df96a