### PR TITLE
Fix imports and cleanup broken test

### DIFF
--- a/library-version-resolver.py
+++ b/library-version-resolver.py
@@ -7,8 +7,6 @@ Designed to run in VS Code on Windows for Raspberry Pi target deployment
 
 import argparse
 import re
-import argparse
-import re
 import subprocess
 import sys
 from dataclasses import dataclass

--- a/src/mower/hardware/gpio_manager.py
+++ b/src/mower/hardware/gpio_manager.py
@@ -329,7 +329,6 @@ class GPIOManager:
                     "gpiozero seemed available but failed initial factory setup, " "forcing MockFactory for simulation."
                 )
                 try:
-                    # type: ignore is needed for mypy compatibility
                     self._DeviceClass.pin_factory = self._MockFactoryClass()  # type: ignore[attr-defined,assignment]
                     logger.info("Using gpiozero.MockFactory for forced simulation.")
                 except Exception as e_mock_force:

--- a/src/mower/simulation/sensors/gps_sim.py
+++ b/src/mower/simulation/sensors/gps_sim.py
@@ -8,7 +8,6 @@ requiring physical hardware.
 
 import math
 import random
-import random
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple, Type, Union

--- a/src/mower/ui/web_ui/run_ui_test.py
+++ b/src/mower/ui/web_ui/run_ui_test.py
@@ -10,11 +10,11 @@ import sys
 # import json
 from pathlib import Path
 
-from src.mower.hardware.imu_fixed import BNO085Sensor  # type: ignore[import]
-from src.mower.hardware.tof_fixed import VL53L0XSensors  # type: ignore[import]
+from mower.hardware.imu_fixed import BNO085Sensor  # type: ignore[import]
+from mower.hardware.tof_fixed import VL53L0XSensors  # type: ignore[import]
 
 # import os
-from src.mower.ui.web_ui.app import create_app
+from mower.ui.web_ui.app import create_app
 
 # Add the project root to the Python path
 project_root = Path(__file__).parent.parent.parent

--- a/tests/obstacle_detection/test_tflite_inference.py
+++ b/tests/obstacle_detection/test_tflite_inference.py
@@ -1,137 +1,43 @@
-"""
-Test module for test_tflite_inference.py.
-"""
+"""Test YOLOv8 TFLite model inference."""
+
+from __future__ import annotations
+
 import argparse
 import time
+from pathlib import Path
 
 import numpy as np
-import tflite_runtime.interpreter as tflite  # Use the runtime interpreter
+import tflite_runtime.interpreter as tflite  # type: ignore
 from PIL import Image
 
 
-def run_inference_test(model_path, image_path, input_size_wh):
-    """
-Test module for test_tflite_inference.py.
-        """
+def run_inference_test(model_path: str, image_path: str, input_size: int) -> None:
+    """Run a simple inference against the supplied model and image."""
+    interpreter = tflite.Interpreter(model_path=model_path)
+    interpreter.allocate_tensors()
 
-    # - - - Load Model - - - print(f"Loading model: {model_path}")
-    try :
-        interpreter = tflite.Interpreter(model_path=model_path)
-        interpreter.allocate_tensors()  # Crucial step
-    except Exception as e:
-        print(f"Error loading model or allocating tensors: {e}")
-        return
+    input_details = interpreter.get_input_details()[0]
+    output_details = interpreter.get_output_details()[0]
 
-    input_details = interpreter.get_input_details()
-    output_details = interpreter.get_output_details()
-    print("Model Input Details: ", input_details)
-    print("Model Output Details: ", output_details)
+    img = Image.open(image_path).resize((input_size, input_size))
+    img_rgb = img.convert("RGB")
+    input_data = np.expand_dims(img_rgb, axis=0).astype(input_details["dtype"])
 
-    # - - - Validate Input Shape - - - try :
-        input_shape = input_details[
-            "shape"
-        ]  # Expected shape(e.g., [1, height, width, 3])
-        # Expected type(e.g., float32, uint8)
-        input_type = input_details["dtype"]
-        print(f"Expected input shape: {input_shape}, type: {input_type}")
+    interpreter.set_tensor(input_details["index"], input_data)
 
-        # Check if expected shape matches specified input size
-        # Shape is usually [batch, height, width, channels]
-        expected_height, expected_width = input_shape, input_shape
-        if expected_height != input_size_wh or expected_width != input_size_wh:
-            print(
-                f"Warning: "
-                Model expected input size({expected_height}x{expected_width}) ""
-                f"differs from specified input size({input_size_wh}x{input_size_wh}). "
-                f"Using model's expected size for preprocessing."'
-            )
-            input_size_wh = (expected_width, expected_height)
+    start = time.time()
+    interpreter.invoke()
+    output_data = interpreter.get_tensor(output_details["index"])
+    end = time.time()
 
-    except (IndexError, KeyError) as e:
-        print(f"Error parsing input details: {e}")
-        return
-
-(f"Loading and preparing image: {image_path}
- f")
-    try :
-        img = Image.open(image_path).resize(input_size_wh)  # Resize to W, H
-        img_rgb = img.convert("RGB")
-        input_data = np.expand_dims(img_rgb, axis=0)  # Add batch dimension
-
-        # Normalize based on model input type
-        if np.issubdtype(input_type, np.float32):
-            input_data = input_data.astype(np.float32) / 255.0
-            print("Normalized input to  for float32 model.")
-        elif np.issubdtype(input_type, np.uint8):
-            input_data = input_data.astype(np.uint8)
-            print("Using uint8 input for quantized model.")
-        else :
-            print(
-                f"Warning: "
-                Unsupported input dtype {input_type}. Assuming no normalization needed.""
-            )
-            input_data = input_data.astype(input_type)
-
-        interpreter.set_tensor(input_details["index"], input_data)
-
-    except FileNotFoundError:
-        print(f"Error: Test image not found at {image_path}")
-        return
-    except Exception as e:
-        print(f"Error preparing input image: {e}")
-        return
-
-    # - - - Run Inference - - - print("Running inference...")
-    start_time = time.time()
-    try :
-        interpreter.invoke()
-    except Exception as e:
-        print(f"Error during interpreter invocation: {e}")
-        return
-    end_time = time.time()
-    inference_time = end_time - start_time
-    print(f"Inference successful! Time: {inference_time: .4f} seconds")
-
-    # - - - Get Output - - - #
-    Output tensor structure depends heavily on the export configuration(e.g., NMS included or not )
-    # Example: YOLOv8 often outputs a tensor like [batch,
-    84, num_proposals] where 84 = 4(box) + 80(class es)
-    # Or it could be multiple output tensors. Check output_details.
-    try :
-        output_data = interpreter.get_tensor(output_details["index"])
-        print(f"Output tensor shape: {output_data.shape}")
-        # Print a small sample of the output for inspection
-        print(
-            "Sample output data(first proposal, first 10 values): ",
-            output_data[0,
-            : 10, 0] if output_data.ndim == 3 else output_data[0, : 10],
-        )
-
-        print("\nBasic inference test complete.")
-        print(
-            "Next steps involve implementing code to parse this output tensor, apply score thresholding, and perform Non - Maximum Suppression(NMS) if not included in the model."
-        )
-
-    except Exception as e:
-        print(f"Error getting or printing output tensor: {e}")
+    print(f"Inference completed in {end - start:.2f}s. Output shape: {output_data.shape}")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Test YOLOv8 TFLite model inference.")
-    parser.add_argument(
-        " - m", " - -model", required=True, help="Path to the.tflite model file."
-    )
-    parser.add_argument(
-        " - i", " - -image", required=True, help="Path to the test image file."
-    )
-    parser.add_argument(
-        " - s",
-        " - -size",
-        type=int,
-        def ault=640,
-        help="Input image size(square) used during export(e.g., 640).",
-    )
+    parser = argparse.ArgumentParser(description="Test YOLOv8 TFLite model inference.")
+    parser.add_argument("-m", "--model", required=True, help="Path to the .tflite model file.")
+    parser.add_argument("-i", "--image", required=True, help="Path to the test image file.")
+    parser.add_argument("-s", "--size", type=int, default=640, help="Input image size.")
     args = parser.parse_args()
 
-    run_inference_test(args.model, args.image, (args.size, args.size))
+    run_inference_test(args.model, args.image, args.size)


### PR DESCRIPTION
### Summary
- remove stray root package `src/__init__.py`
- fix corrupted `test_tflite_inference` script
- drop invalid type-ignore comment in `gpio_manager`
- clean up duplicated imports
- update `run_ui_test` to use proper package names

### Test Plan
- `pre-commit run --all-files` *(fails: flake8 and mypy errors)*
- `mypy src/` *(fails: numerous type errors)*
- `PYTHONPATH=src pytest -q` *(fails: cv2 import error)*

------
https://chatgpt.com/codex/tasks/task_e_684088e1e74083229ac89d3f2f7c93aa