### PR TITLE
Update docs for Python 3.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Refer to coverage targets in [docs/test_coverage.md](docs/test_coverage.md)
 ## Prerequisites
 
 - Raspberry Pi 4B or newer (4GB RAM recommended)
-- Python 3.11 (Bookworm as of June 2025)
+- Python 3.9 or newer (tested with Python 3.11)
 - Raspberry Pi OS Bookworm (fully updated)
 - Camera module (v2 or v3 recommended)
 - Various sensors (see Hardware Setup)

--- a/docs/hardware_setup.md
+++ b/docs/hardware_setup.md
@@ -6,7 +6,7 @@ This document provides detailed instructions for setting up the hardware compone
 
 ## Software Dependencies
 
-- Python 3.10 or newer is required (Raspberry Pi OS Bookworm).
+- Python 3.9 or newer is required (Raspberry Pi OS Bookworm).
 - Install system dependencies:
 
 ```bash

--- a/docs/yolov8_setup.md
+++ b/docs/yolov8_setup.md
@@ -4,7 +4,7 @@ This document describes how to set up a YOLOv8 TFLite model for obstacle detecti
 
 ## Prerequisites
 
-- Python 3.8+
+- Python 3.9+
 - `pip` (Python package installer)
 - Git (for cloning the repository)
 - An internet connection (for downloading the base `.pt` model and dependencies if needed)


### PR DESCRIPTION
### Summary
- clarify Python version requirement across docs
- revert temporary test helper code

### Test Plan
- `pre-commit run --files README.md docs/hardware_setup.md docs/yolov8_setup.md src/mower/config_management/__init__.py src/mower/mower.py src/mower/state_management/states.py src/mower/ui/web_ui/run_ui_test.py` *(fails: flake8 and mypy errors)*
- `mypy src/` *(fails: 215 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: dotenv)*

### Checklist
- [x] Code formatted with Black
- [ ] Type hints complete
- [x] Docs updated

------
https://chatgpt.com/codex/tasks/task_e_6841a66d148c8322ac60d9a7bf43cc95