### PR TITLE
Fix install script for distutils packages

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1001,7 +1001,8 @@ install_python_dependencies() {
 
     print_info "Installing Python dependencies from requirements.txt..."
     if [ -f "requirements.txt" ]; then
-        "$PIP_CMD" install --break-system-packages -r requirements.txt
+        # Avoid uninstall errors for distutils packages shipped by apt
+        "$PIP_CMD" install --break-system-packages --ignore-installed -r requirements.txt
         check_command "Installing dependencies from requirements.txt" || return 1
     else
         print_error "requirements.txt not found."


### PR DESCRIPTION
### Summary

- avoid failing when pip encounters distutils packages
- install_dependencies now uses `--ignore-installed` so `pip` won't try to uninstall OS packages

### Test Plan

- [ ] `pytest -q` *(fails: No module named 'dotenv')*
- [ ] `pytest -m integration` *(fails: No module named 'dotenv')*
- [x] `pre-commit run --files install_requirements.sh`


------
https://chatgpt.com/codex/tasks/task_e_684354274d9c83229af438c7a4bfac11