### PR TITLE
Fix Coral installation for Python 3.11

### DIFF
--- a/docs/coral_setup.md
+++ b/docs/coral_setup.md
@@ -32,8 +32,14 @@ echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sud
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo apt-get update
 
-# Install the Edge TPU runtime and Python libraries
-sudo apt-get install libedgetpu1-std python3-pycoral
+# Install the Edge TPU runtime
+sudo apt-get install libedgetpu1-std
+
+# Python 3.11 users (Raspberry Pi OS Bookworm)
+# Install PyCoral using the official Coral pip repository
+sudo python3 -m pip install --break-system-packages \
+    --extra-index-url https://google-coral.github.io/py-repo/ \
+    pycoral~=2.0
 ```
 
 For other systems, please refer to the [official Coral documentation](https://coral.ai/docs/accelerator/get-started/).

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1241,8 +1241,18 @@ install_specific_feature() {
                 check_command "Installing Edge TPU runtime" || print_error "Failed to install Edge TPU runtime."
 
                 print_info "Installing PyCoral library (official Coral method: python3-pycoral)..."
-                sudo apt-get install -y python3-pycoral
-                check_command "Installing python3-pycoral" || POST_INSTALL_MESSAGES+="[ERROR] Failed to install python3-pycoral via apt.\\n"
+                if sudo apt-get install -y python3-pycoral; then
+                    check_command "Installing python3-pycoral"
+                else
+                    print_warning "python3-pycoral package unavailable for this Python version. Falling back to pip."
+                    if sudo python3 -m pip install --break-system-packages \
+                        --extra-index-url https://google-coral.github.io/py-repo/ \
+                        "pycoral~=2.0"; then
+                        check_command "Installing pycoral via pip"
+                    else
+                        POST_INSTALL_MESSAGES+="[ERROR] Failed to install pycoral via apt and pip.\\n"
+                    fi
+                fi
             fi
             print_success "Coral TPU support setup attempted."
             mark_step_completed "coral_tpu_setup"
@@ -1480,8 +1490,18 @@ run_full_installation() {
                 check_command "Installing Edge TPU runtime" || print_error "Failed to install Edge TPU runtime."
 
                 print_info "Installing PyCoral library (python3-pycoral via apt)..."
-                sudo apt-get install -y python3-pycoral
-                check_command "Installing python3-pycoral" || POST_INSTALL_MESSAGES+="[ERROR] Failed to install python3-pycoral via apt.\n"
+                if sudo apt-get install -y python3-pycoral; then
+                    check_command "Installing python3-pycoral"
+                else
+                    print_warning "python3-pycoral package unavailable for this Python version. Falling back to pip."
+                    if sudo python3 -m pip install --break-system-packages \
+                        --extra-index-url https://google-coral.github.io/py-repo/ \
+                        "pycoral~=2.0"; then
+                        check_command "Installing pycoral via pip"
+                    else
+                        POST_INSTALL_MESSAGES+="[ERROR] Failed to install pycoral via apt and pip.\n"
+                    fi
+                fi
             fi
             print_success "Coral TPU support setup attempted."
             mark_step_completed "coral_tpu_setup"


### PR DESCRIPTION
### Summary

- correct PyCoral install instructions for Bookworm / Python 3.11
- update fallback in the installer to use the official Coral pip index

### Test Plan

- [ ] `pytest -q` *(fails: missing dependencies)*
- [ ] `pre-commit run --all-files` *(fails with various issues)*
- [ ] `mypy src/` *(fails with typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684367968f5c8322918a8b8c16b91d5e