### PR TITLE
Fix temperature display and map centering

### DIFF
--- a/src/mower/ui/web_ui/static/js/main.js
+++ b/src/mower/ui/web_ui/static/js/main.js
@@ -75,15 +75,26 @@ function formatSensorValue(value, format = 'number', unit = '') {
 }
 
 // Unit conversion functions
+function normalizeToCelsius(temp) {
+  let value = parseFloat(temp);
+  if (typeof temp === 'string' && temp.toUpperCase().includes('F')) {
+    value = (parseFloat(temp) - 32) * 5/9;
+  } else if (value > 60) {
+    value = (value - 32) * 5/9;
+  }
+  return value;
+}
+
 function convertTemperature(celsius, unit) {
+  const base = normalizeToCelsius(celsius);
   if (unit === 'fahrenheit') {
     return {
-      value: (celsius * 9/5) + 32,
+      value: (base * 9/5) + 32,
       unit: '°F'
     };
   }
   return {
-    value: celsius,
+    value: base,
     unit: '°C'
   };
 }

--- a/src/mower/ui/web_ui/static/js/map.js
+++ b/src/mower/ui/web_ui/static/js/map.js
@@ -132,12 +132,15 @@ function initMap() {
         return;
     }
 
-    // Default map center (e.g., a generic location, can be updated later)
-    const defaultCenter = { lat: 40.7128, lng: -74.0060 }; // New York
+    // Default map center based on data attributes or fallback
+    const mapElement = document.getElementById('map');
+    const initialLat = parseFloat(mapElement?.dataset.initialLat) || 0;
+    const initialLng = parseFloat(mapElement?.dataset.initialLng) || 0;
+    const defaultCenter = { lat: initialLat, lng: initialLng };
 
-    window.map = new google.maps.Map(document.getElementById('map'), {
+    window.map = new google.maps.Map(mapElement, {
         center: defaultCenter,
-        zoom: 8, // Adjust zoom as needed
+        zoom: 18,
         mapTypeId: 'roadmap', // Default to roadmap, user can toggle satellite
         mapTypeControl: true,
         mapTypeControlOptions: {

--- a/src/mower/ui/web_ui/static/js/mowing-patterns.js
+++ b/src/mower/ui/web_ui/static/js/mowing-patterns.js
@@ -41,14 +41,17 @@ document.addEventListener("DOMContentLoaded", function () {
  * Initialize the map with Google Maps
  */
 function initMap() {
-  // Default center (will be updated with boundary data)
-  const defaultCenter = { lat: 37.7749, lng: -122.4194 }; // San Francisco as default
+  // Determine initial center from data attributes or fallback
+  const mapElement = document.getElementById("map");
+  const initialLat = parseFloat(mapElement?.dataset.initialLat) || 0;
+  const initialLng = parseFloat(mapElement?.dataset.initialLng) || 0;
+  const defaultCenter = { lat: initialLat, lng: initialLng };
 
   // Initialize geocoder for address searches
   geocoder = new google.maps.Geocoder();
 
   // Initialize the map - default to satellite view
-  map = new google.maps.Map(document.getElementById("map"), {
+  map = new google.maps.Map(mapElement, {
     zoom: 18,
     center: defaultCenter,
     mapTypeId: google.maps.MapTypeId.SATELLITE, // Default to satellite view

--- a/src/mower/ui/web_ui/templates/map.html
+++ b/src/mower/ui/web_ui/templates/map.html
@@ -238,7 +238,7 @@
                     </div>
                 </div>
 
-                <div id="map" class="map-container"></div>
+                <div id="map" class="map-container" data-initial-lat="{{ map_center_lat }}" data-initial-lng="{{ map_center_lng }}"></div>
                 <div class="coverage-info mt-2">
                     <span>Coverage:</span>
                     <div class="coverage-bar">


### PR DESCRIPTION
## Summary
- load .env early in app
- center `/map` page on mower GPS coordinates
- show map coordinates in template for JS
- initialize map using coordinates from data attributes
- normalize temperature inputs and convert correctly

## Testing
- `pytest -q tests/ui/web_ui/test_validation.py::TestValidateAddress::test_valid_address_premise_granularity`

------
https://chatgpt.com/codex/tasks/task_e_6870423aa0348322b0ae84f0b79baa0e