### PR TITLE
Add ToF calibration support via WebUI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,10 @@ RIGHT_TOF_XSHUT=23  # GPIO23 (pin 16)
 LEFT_TOF_INTERRUPT=6 #GPIO6 (pin 31)
 RIGHT_TOF_INTERRUPT=12 # GPIO12 (pin 32)
 
+# Ground-plane cutoff distances for drop-off detection (cm)
+TOF_GROUND_CUTOFF_LEFT=120
+TOF_GROUND_CUTOFF_RIGHT=120
+
 
 # --- Mower ---
 MOWER_NAME=AutonoMow

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -132,6 +132,8 @@ TOF_GROUND_CUTOFF_RIGHT=<calibrated right sensor cutoff cm>
 
 These values are used by the drop‑off detector to distinguish real cliffs from angled ground readings.
 
+Use the **Calibrate ToF** button on the WebUI Diagnostics page to automatically measure and store these values when the mower is on a flat surface.
+
 ## Changing Configuration
 
 ### During Installation

--- a/docs/hardware_setup.md
+++ b/docs/hardware_setup.md
@@ -189,13 +189,12 @@ The Autonomous Mower requires several hardware components to function properly. 
 
 ### ToF Ground‑Plane Calibration
 
-To avoid false drop‑off detections when these angled sensors look ahead and down, calibrate each front ToF with this procedure:
+To avoid false drop‑off detections when these angled sensors look ahead and down, calibrate both front ToF sensors in software:
 
-1. Place a solid vertical board (≥1 cm thick) perpendicular to the beam of the front‑left VL53L0X.
-2. Slowly move the board away until the system no longer reports a valid distance (reading becomes infinite or missing).
-3. Measure that distance in centimeters and note it as the left ground‑plane cutoff.
-4. Repeat steps 1‑3 for the front‑right VL53L0X to obtain the right ground‑plane cutoff.
-5. You will enter both distances into your `.env` as `TOF_GROUND_CUTOFF_LEFT` and `TOF_GROUND_CUTOFF_RIGHT`.
+1. Angle the sensors so they can see the ground a short distance in front of the mower while still detecting drop‑offs.
+2. Place the mower on a flat, smooth surface.
+3. In the WebUI open the **Diagnostics** page and press **Calibrate ToF**.
+4. The mower records the current left and right distances as `TOF_GROUND_CUTOFF_LEFT` and `TOF_GROUND_CUTOFF_RIGHT` in the `.env` file.
 
 ![ToF Sensors Installation](images/tof_installation.jpg)
 

--- a/src/mower/ui/web_ui/templates/diagnostics.html
+++ b/src/mower/ui/web_ui/templates/diagnostics.html
@@ -304,14 +304,28 @@ endblock %} {% block content %}
                   >Not Set</span
                 >
               </div>
-              <button class="btn btn-primary" id="calibrateGPSBtn">
-                <i class="fas fa-satellite"></i> Set GPS Baseline
-              </button>
-            </div>
-          </div>
+          <button class="btn btn-primary" id="calibrateGPSBtn">
+            <i class="fas fa-satellite"></i> Set GPS Baseline
+          </button>
+        </div>
+      </div>
+
+      <div class="calibration-item">
+        <div class="calibration-header">
+          <h4>ToF Ground Calibration</h4>
+        </div>
+        <div class="calibration-content">
+          <p>
+            Ensure the mower is on a flat surface with the front ToF sensors angled toward the ground, then press Calibrate.
+          </p>
+          <button class="btn btn-primary" id="calibrateToFBtn">
+            <i class="fas fa-ruler"></i> Calibrate ToF
+          </button>
         </div>
       </div>
     </div>
+  </div>
+</div>
   </div>
 </div>
 
@@ -405,6 +419,27 @@ endblock %} {% block content %}
           "GPS Baseline Calibration",
           "This will set the GPS baseline for improved positioning. Place the mower in an open area with a clear view of the sky and keep it stationary during calibration."
         );
+      });
+
+    document
+      .getElementById("calibrateToFBtn")
+      .addEventListener("click", function () {
+        if (
+          confirm(
+            "Place the mower on a flat surface with the ToF sensors angled toward the ground, then press OK to calibrate."
+          )
+        ) {
+          fetch("/api/calibrate_tof", { method: "POST" })
+            .then((r) => r.json())
+            .then((d) => {
+              if (d.success) {
+                alert(`Calibration saved (L: ${d.left}cm, R: ${d.right}cm)`);
+              } else {
+                alert("Calibration failed: " + d.error);
+              }
+            })
+            .catch((e) => alert("Calibration failed: " + e));
+        }
       });
 
     // Modal control


### PR DESCRIPTION
## Summary
- document ToF sensor calibration and update config guide
- expose `/api/calibrate_tof` endpoint to store ground cutoff distances
- add calibration button on diagnostics page
- add placeholders for new env vars

## Testing
- `pre-commit run --files src/mower/ui/web_ui/app.py src/mower/ui/web_ui/templates/diagnostics.html docs/hardware_setup.md docs/configuration_guide.md .env.example`
- `pytest -q` *(fails: SystemExit: 1)*

------
https://chatgpt.com/codex/tasks/task_e_687060c3bb1c83228674621d24043b05