### PR TITLE
Fix manual control endpoints

### DIFF
--- a/src/mower/ui/web_process.py
+++ b/src/mower/ui/web_process.py
@@ -332,6 +332,19 @@ class DummyResourceManager:
         pass
     
     def execute_command(self, command, params):
+        params = params or {}
+        if command == "manual_drive":
+            self.logger.info(f"Dummy manual drive: {params}")
+            return {"success": True}
+        if command == "blade_on":
+            self.logger.info("Dummy blade on")
+            return {"success": True}
+        if command == "blade_off":
+            self.logger.info("Dummy blade off")
+            return {"success": True}
+        if command == "set_blade_speed":
+            self.logger.info(f"Dummy blade speed {params.get('speed')}")
+            return {"success": True}
         return {"success": True, "result": f"Command {command} executed"}
 
 def start_web():


### PR DESCRIPTION
## Summary
- add blade controller alias and stop logic fix
- add `execute_command` to ResourceManager for manual driving and blade control
- implement dummy command handling in web process

## Testing
- `pytest -k resource_manager -q` *(fails: INTERNALERROR: SystemExit: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68706a34b4948322ad91696cff5cfdfa